### PR TITLE
New Building Structure

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -117,64 +117,8 @@ board_list = { 'SAM7-EX256' : [ 'AT91SAM7X256', 'AT91SAM7X512' ],
 cpu_list = sum([board_list[i] for i in board_list],[])
 
 
-# ROMFS file list "groups"
-# To include a file in a ROMFS build, include it in a group here (or create one
-# if you need) and make sure the group is included on your platform's file_list
-# definition (right after this).
-
-# The following table will be left here just as an example
-# eLua examples were removed from the distro since v0.8
-#romfs = { 'bisect' : [ 'bisect.lua' ],
-#          'hangman' : [ 'hangman.lua' ],
-#          'lhttpd' : [ 'index.pht', 'lhttpd.lua', 'test.lua' ],
-#          'led' : [ 'led.lua' ],
-#          'piano' : [ 'piano.lua' ],
-#          'pwmled' : [ 'pwmled.lua' ],
-#          'tvbgone' : [ 'tvbgone.lua', 'codes.bin' ],
-#          'hello' : [ 'hello.lua' ],
-#          'info' : [ 'info.lua' ],
-#          'morse' : [ 'morse.lua' ],
-#          'dualpwm' : [ 'dualpwm.lua' ],
-#          'adcscope' : [ 'adcscope.lua' ],
-#          'adcpoll' : [ 'adcpoll.lua' ],
-#          'life' : [ 'life.lua' ],
-#          'logo' : ['logo.lua', 'logo.bin' ],
-#          'pong' : [ 'pong.lua' ],
-#          'spaceship' : [ 'spaceship.lua' ],
-#          'tetrives' : [ 'tetrives.lua' ],
-#          'snake' : [ 'snake.lua' ],
-#          'dataflash' : [ 'dataflash.lua' ],
-#          'pachube' : [ 'pachube_demo.lua' ],
-#          'inttest' : [ 'inttest.lua' ]
-#        }
-
 romfs = {
         }
-
-# List of board/romfs data combinations
-# The following table will be left here just as an example
-# eLua examples were removed from the distro since v0.8
-#file_list = { 'SAM7-EX256' : [ 'bisect', 'hangman' , 'led', 'piano', 'hello', 'info', 'morse' ],
-#              'EK-LM3S1968' : [ 'bisect', 'hangman', 'pong', 'led', 'piano', 'pwmled', 'hello', 'info', 'morse', 'adcscope', 'adcpoll', 'logo', 'spaceship', 'tetrives', 'snake' ],
-#              'EK-LM3S8962' : [ 'lhttpd','bisect', 'led', 'pachube' ],
-#              'EK-LM3S6965' : [ 'bisect', 'hangman', 'pong', 'led', 'piano', 'pwmled', 'hello', 'info', 'morse', 'adcscope', 'adcpoll', 'logo', 'tetrives' ],
-#              'EK-LM3S9B92' : [ 'bisect', 'hangman', 'led', 'pwmled', 'hello', 'info', 'adcscope','adcpoll', 'life' ],
-#              'STR9-COMSTICK' : [ 'bisect', 'hangman', 'led', 'hello', 'info' ],
-#              'STR-E912' : [ 'bisect', 'hangman', 'led', 'hello', 'info', 'piano', 'adcscope' ],
-#              'PC' : [ 'bisect', 'hello', 'info', 'life', 'hangman' ],
-#              'SIM' : [ 'bisect', 'hello', 'info', 'life', 'hangman' ],
-#              'LPC-H2888' : [ 'bisect', 'hangman', 'led', 'hello', 'info' ],
-#              'MOD711' : [ 'bisect', 'hangman', 'led', 'hello', 'info', 'dualpwm' ],
-#              'STM3210E-EVAL' : [ 'bisect', 'hello', 'info' ],
-#              'ATEVK1100' : [ 'bisect', 'hangman', 'led', 'hello', 'info', 'dataflash' ],
-#              'ATEVK1101' : [ 'bisect', 'led', 'hello', 'info', 'dataflash' ],
-#              'ET-STM32' : [ 't' ],
-#              'EAGLE-100' : [ 'bisect', 'hangman', 'lhttpd', 'led', 'hello', 'info' ],
-#              'ELUA-PUC' : [ 'bisect', 'hangman', 'led', 'hello', 'info', 'pwmled', 'adcscope', 'adcpoll', 'inttest' ],
-#              'MBED' : [ 'bisect', 'hangman', 'hello', 'info', 'led', 'pwmled', 'dualpwm', 'life', 'adcscope', 'adcpoll' ],
-#              'MIZAR32' : [ ],
-#              'NETDUINO': [ ],
-#}
 
 file_list = { 'SAM7-EX256' : [ ],
               'EK-LM3S1968' : [ ],
@@ -270,8 +214,15 @@ vars.AddVariables(
                     'verbatim',
                     allowed_values=[ 'verbatim' , 'compress', 'compile' ] ) )
 
-
 vars.Update(comp)
+
+project = ARGUMENTS.get ('project', '')
+try:
+	execfile (project + '/conf.py')
+	comp['board']=BOARD
+except:
+	print ('invalid project ' + project)
+	exit (1)
 
 if not GetOption( 'help' ):
 
@@ -383,7 +334,7 @@ if not GetOption( 'help' ):
     print "*********************************"
     print
 
-  output = 'elua_' + comp['target'] + '_' + comp['cpu'].lower()
+  output = project + 'elua_' + comp['target'] + '_' + comp['cpu'].lower()
 
   comp.Append(CPPDEFINES = { 'ELUA_CPU' : comp['cpu'],
                              'ELUA_BOARD' : comp['board'],
@@ -465,10 +416,10 @@ if not GetOption( 'help' ):
   # Make ROM File System first
   if not GetOption( 'clean' ):
     print "Building ROM File System..."
-    romdir = "romfs"
+    romdir = project + "romfs/"
     flist = []
-    for sample in file_list[ comp['board'] ]:
-      flist += romfs[ sample ]
+    for file in os.listdir (romdir):
+      flist += [file]
     import mkfs
     mkfs.mkfs( romdir, "romfiles", flist, comp['romfs'], compcmd )
     print

--- a/bin/elua
+++ b/bin/elua
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+import sys
+import os
+
+conf_name = 'conf.py'
+
+def print_help ():
+	print "usage:"
+	print "elua --build"
+	print "elua --create <project_name> <board_name>"
+	print "elua --recreate <project_name> <board_name>"
+	print """\n\n\
+build: build an eLua image from the "%s" file from the current folder.
+create: create a new romfs and a configuration file for the project.
+""" % (conf_name)
+
+def print_licence ():
+	print """\
+--------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011 LedLab-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+--------------------------------------------------------------------------------
+"""
+
+def get_template (board):
+	# Create a template for a given board.
+	template = """
+BOARD = "%s"
+""" % board.upper ()
+	return template
+
+def write_template (board, projdir):
+	f = open (projdir + '/' + conf_name, 'w')
+	f.write (get_template (board))
+	f.close ()
+
+def create(board, proj, projdir):
+	try:
+		os.makedirs (projdir + '/romfs')
+		print ('creating project %s' % proj)
+	except:
+		print ('unable to create the folder "%s"' % projdir)
+		print ('check if already exists')
+		exit (2)
+	write_template (board, projdir)
+
+def main ():
+	elua_home = os.path.dirname (sys.argv[0]) + "/.."
+	projdir = os.getcwd ()
+	
+	print_licence ()
+	
+	try:
+		cmd = sys.argv[1]
+	except:
+		print "invalid argument\n"
+		print_help ()
+		exit (1)
+	if cmd == '--build':
+		os.system ("scons -C%s toolchain=codesourcery prog project=%s/" % (elua_home, projdir))
+	elif cmd == '--create':
+		try:
+			proj = sys.argv[2]
+			board = sys.argv[3]
+		except:
+			print ('invalid project name or board')
+			exit (3)
+		create (board, proj, projdir+'/'+proj)
+	elif cmd == '--recreate':
+		try:
+			proj = sys.argv[2]
+			board = sys.argv[3]
+		except:
+			print ('invalid project name or board')
+			print_help ()
+			exit (3)
+		print ('conf.py overwriten')
+		projdir = project_folder + '/' + proj
+		write_template (board, projdir)
+	elif cmd == '--help':
+		print_help ()
+		exit (0)
+	else:
+		print ('invalid command: %s' % cmd)
+		print_help ()
+
+if __name__ == "__main__":
+	    main()


### PR DESCRIPTION
The main objective is to transform the building process into a more project oriented view.

To do that:
- created a bin/elua (in python) that abstracts the usage of scons with the commands:
  elua --create <proj> <board>
  cd proj
  elua --build

--create: creates a conf.py that for now have BOARD="NAME" and a romfs/ folder. The elua now adds every file in the romfs, which I think is more intuitive to the user.
 Later on, if this path is accepted, the idea is to expand into a user level modules and components configuration that can be tuned for each project.

--build: Builds elua with the configuration from conf.py and the files from romfs/ and generates the image in the project folder.

So, to distribute an elua app the user only have to provide

conf.py
romfs/his_files.lua
