### PR TITLE
Fix CR->NL and NL->CR transations on linux

### DIFF
--- a/src/serial/serial_posix.c
+++ b/src/serial/serial_posix.c
@@ -112,6 +112,7 @@ int ser_setup( ser_handler id, u32 baud, int databits, int parity, int stopbits 
   termdata.c_iflag &= ~( IXON | IXOFF | IXANY );
 
   // Raw input
+  termdata.c_iflag &= ~( INLCR | ICRNL );
   termdata.c_lflag &= ~( ICANON | ECHO | ECHOE | ISIG );
 
   // Raw output


### PR DESCRIPTION
As posted on the eLua mailing list.  On linux, without this patch, table value with key 13 on the rpc server become the value corresponding to the key 10 on the client when the table is fetched with get().
