### PR TITLE
Timer Bugfix for lm3s

### DIFF
--- a/src/platform/lm3s/platform.c
+++ b/src/platform/lm3s/platform.c
@@ -557,7 +557,7 @@ timer_data_type platform_s_timer_op( unsigned id, int op,timer_data_type data )
       break;
 
     case PLATFORM_TIMER_OP_READ:
-      res = MAP_TimerValueGet( base, TIMER_A );
+      res = 0xFFFFFFFF - MAP_TimerValueGet( base, TIMER_A );
       break;
 
     case PLATFORM_TIMER_OP_SET_CLOCK:


### PR DESCRIPTION
Maybe not the most elegant solution, but it does work

The following functions are working correctly now:
tmr.getdiffnow(..)
tmr.gettimediff(..)
and uart.read(..) with timeout

tested with lm3s9d92
