### PR TITLE
Fixed "lua: attempt to call a string value" when loading platform libraries

### DIFF
--- a/src/lua/linit.c
+++ b/src/lua/linit.c
@@ -91,7 +91,7 @@ LUALIB_API int luaopen_platform (lua_State *L)
   unsigned i;
   for (i = 0; i < sizeof(platform_open_funcs) / sizeof(lua_CFunction); i++) {
     lua_pushcfunction(L, platform_open_funcs[i]);
-    lua_call(L, 1, 0);
+    lua_call(L, 0, 0);
   }
   return 0;
 }


### PR DESCRIPTION
No args on the stack for call.
