### PR TITLE
Add status return to can.send() and underlying platform_can_send() functions.

### DIFF
--- a/doc/eluadoc/arch_platform_can.lua
+++ b/doc/eluadoc/arch_platform_can.lua
@@ -48,7 +48,7 @@ enum
       ret = "the actual speed set for the CAN interface. Depending on the hardware, this may have a different value than the $clock$ argument."
     },
 
-    {  sig = "void #platform_can_send#( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data );",
+    {  sig = "int #platform_can_send#( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data );",
        desc = "Send message over the CAN bus.",
        args =
        {
@@ -58,6 +58,7 @@ enum
           "$len$ - message length in bytes (8 or fewer)",
           "$message$ - pointer to message, 8 or fewer bytes in length"
        },
+       ret = "PLATFORM_OK for success, PLATFORM_ERR if the message wasn't sent."
     },
 
      {  sig = "int #platform_can_recv#( unsigned id, u32 *canid, u8 *idtype, u8 *len, u8 *data );",

--- a/inc/platform.h
+++ b/inc/platform.h
@@ -154,7 +154,7 @@ enum
 
 int platform_can_exists( unsigned id );
 u32 platform_can_setup( unsigned id, u32 clock );
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data );
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data );
 int platform_can_recv( unsigned id, u32 *canid, u8 *idtype, u8 *len, u8 *data );
 
 // *****************************************************************************

--- a/src/modules/can.c
+++ b/src/modules/can.c
@@ -21,7 +21,7 @@ static int can_setup( lua_State* L )
   return 1;
 }
 
-// Lua: send( id, canid, canidtype, message )
+// Lua: success = send( id, canid, canidtype, message )
 static int can_send( lua_State* L )
 {
   size_t len;
@@ -36,9 +36,12 @@ static int can_send( lua_State* L )
   if ( len > PLATFORM_CAN_MAXLEN )
     return luaL_error( L, "message exceeds max length" );
   
-  platform_can_send( id, canid, idtype, len, ( const u8 * )data );
+  if( platform_can_send( id, canid, idtype, len, ( const u8 * )data ) == PLATFORM_OK )
+    lua_pushboolean( L, 1 );
+  else
+    lua_pushboolean( L, 0 );
   
-  return 0;
+  return 1;
 }
 
 // Lua: canid, canidtype, message = recv( id )

--- a/src/platform/lm3s/platform.c
+++ b/src/platform/lm3s/platform.c
@@ -338,7 +338,7 @@ u32 platform_can_setup( unsigned id, u32 clock )
   return clock;
 }
 
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
 {
   tCANMsgObject msg_tx;
   const char *s = ( char * )data;
@@ -362,6 +362,8 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
 
   can_tx_flag = 1;
   CANMessageSet(CAN0_BASE, CAN_MSG_OBJ_TX, &msg_tx, MSG_OBJ_TYPE_TX);
+
+  return PLATFORM_OK;
 }
 
 int platform_can_recv( unsigned id, u32 *canid, u8 *idtype, u8 *len, u8 *data )

--- a/src/platform/lpc17xx/platform.c
+++ b/src/platform/lpc17xx/platform.c
@@ -753,7 +753,7 @@ u32 platform_can_setup( unsigned id, u32 clock )
   return (SystemCoreClock / 20) / ((div & 0x3FF)+1);
 }
 
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
 {
   CAN_MSG_Type msg_tx;
   LPC_CAN_TypeDef * canx;
@@ -762,7 +762,7 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
   {
     case 0: canx = LPC_CAN1; break;
     case 1: canx = LPC_CAN2; break;
-    default: return;
+    default: return PLATFORM_ERR;
   }
 
   // Wait for outgoing messages to clear
@@ -782,6 +782,8 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
   }
 
   CAN_SendMsg(canx, &msg_tx);
+
+  return PLATFORM_OK;
 }
 
 int platform_can_recv( unsigned id, u32 *canid, u8 *idtype, u8 *len, u8 *data )

--- a/src/platform/stm32/platform.c
+++ b/src/platform/stm32/platform.c
@@ -376,7 +376,7 @@ u32 platform_can_op( unsigned id, int op, u32 data )
 }
 */
 
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
 {
   CanTxMsg TxMessage;
   const char *s = ( char * )data;
@@ -399,8 +399,11 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
   
   d = ( char * )TxMessage.Data;
   DUFF_DEVICE_8( len,  *d++ = *s++ );
-  
-  CAN_Transmit( CAN1, &TxMessage );
+
+  if( CAN_Transmit( CAN1, &TxMessage ) == CAN_TxStatus_NoMailBox )
+    return PLATFORM_ERR;
+
+  return PLATFORM_OK;
 }
 
 void USB_LP_CAN_RX0_IRQHandler(void)

--- a/src/platform/stm32f2/platform.c
+++ b/src/platform/stm32f2/platform.c
@@ -1031,7 +1031,10 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
   d = ( char * )TxMessage.Data;
   DUFF_DEVICE_8( len,  *d++ = *s++ );
 
-  CAN_Transmit( stm32_can[id], &TxMessage );
+  if( CAN_Transmit( stm32_can[id], &TxMessage ) == CAN_TxStatus_NoMailBox )
+    return PLATFORM_ERR;
+
+  return PLATFORM_OK;
 }
 
 void USB_LP_CAN_RX0_IRQHandler(void)

--- a/src/platform/stm32f4/platform.c
+++ b/src/platform/stm32f4/platform.c
@@ -983,7 +983,7 @@ u32 platform_can_op( unsigned id, int op, u32 data )
   return res;
 }
 
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
 {
   CanTxMsg TxMessage;
   const char *s = ( char * )data;
@@ -1007,7 +1007,10 @@ void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *dat
   d = ( char * )TxMessage.Data;
   DUFF_DEVICE_8( len,  *d++ = *s++ );
 
-  CAN_Transmit( CAN1, &TxMessage );
+  if( CAN_Transmit( CAN1, &TxMessage ) == CAN_TxStatus_NoMailBox )
+    return PLATFORM_ERR;
+
+  return PLATFORM_OK;
 }
 
 void USB_LP_CAN_RX0_IRQHandler(void)

--- a/src/platform/str9/platform.c
+++ b/src/platform/str9/platform.c
@@ -956,13 +956,15 @@ u32 platform_can_setup( unsigned id, u32 clock )
   return clock;
 }
 
-void platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
+int platform_can_send( unsigned id, u32 canid, u8 idtype, u8 len, const u8 *data )
 {
   TxCanMsg.IdType = idtype;
   TxCanMsg.Id = canid;
   TxCanMsg.Dlc = len;
   memcpy(TxCanMsg.Data, data, len);
-  CAN_SendMessage((idtype & ELUA_CAN_ID_EXT) ? CAN_TX_EXT_MSGOBJ : CAN_TX_STD_MSGOBJ, &TxCanMsg);
+  if ( CAN_SendMessage((idtype & ELUA_CAN_ID_EXT) ? CAN_TX_EXT_MSGOBJ : CAN_TX_STD_MSGOBJ, &TxCanMsg) == SUCCESS )
+    return PLATFORM_OK;
+  return PLATFORM_ERR;
 }
 
 int platform_can_recv( unsigned id, u32 *canid, u8 *idtype, u8 *len, u8 *data )


### PR DESCRIPTION
Now, can.send() returns a boolean result to indicate whether the message
was successfully sent or not. The various platform functions differ in how
they handled the situation where all CAN transmitters are occupied. In
particular, the STM32x and STR9 implementations ignored the status returns
from the underlying libraries and so if all the CAN transmitters were busy,
the latest message simply got thrown away. Now, can.send() returns true/false
to indicate if the message really did get queued for transmission. All
platforms should behave the same as before.
