### PR TITLE
Ported to STM32F401 Nucleo board.

### DIFF
--- a/boards/known/stm32f4-nucleo.lua
+++ b/boards/known/stm32f4-nucleo.lua
@@ -1,0 +1,31 @@
+-- STM32F4-NUCLEO build configuration
+
+return {
+  cpu = 'stm32f401re',
+  components = {
+    sercon = { uart = "1", speed = 115200 },
+    romfs = true,
+    cdc = false,
+    advanced_shell = true,
+    term = { lines = 25, cols = 80 },
+    linenoise = { shell_lines = 10, lua_lines = 50 },
+    stm32f4_enc = true,
+    rpc = { uart = "0", speed = 115200 },
+    adc = { buf_size = 2 },
+    xmodem = true,
+    cints = true, 
+    luaints = true
+  },
+  config = {
+    egc = { mode = "alloc" },
+    vtmr = { num = 4, freq = 10 },
+    ram = { internal_rams = 1 },
+    clocks = { external = 8000000, cpu = 84000000 },
+    stm32f4_uart_pins = { con_rx_port = 0, con_rx_pin = 3, con_tx_port = 0, con_tx_pin = 2 }
+  },
+  modules = {
+    generic = { 'all', "-i2c", "-net" },
+    platform = 'all',
+  },
+}
+

--- a/build_data.lua
+++ b/build_data.lua
@@ -111,7 +111,7 @@ local platform_list =
   str7 = { cpus = { 'STR711FR2' }, arch = 'arm' },
   stm32f2 = { cpus = { 'STM32F205RF' }, arch = 'cortexm' },
   stm32 = { cpus = { 'STM32F103ZE', 'STM32F103RE' }, arch = 'cortexm' },
-  stm32f4 = { cpus =  { 'STM32F407VG', 'STM32F407ZG' }, arch = 'cortexm' },
+  stm32f4 = { cpus =  { 'STM32F401RE', 'STM32F407VG', 'STM32F407ZG' }, arch = 'cortexm' },
   avr32 = { cpus = { 'AT32UC3A0128', 'AT32UC3A0256', 'AT32UC3A0512', 'AT32UC3B0256' }, arch = 'avr32' },
   lpc24xx = { cpus = { 'LPC2468' }, arch = 'arm' },
   lpc17xx = { cpus = { 'LPC1768' }, arch = 'cortexm' }

--- a/src/platform/stm32f4/conf.lua
+++ b/src/platform/stm32f4/conf.lua
@@ -8,10 +8,12 @@ addi( sf( 'src/platform/%s/FWLib/USB/STM32_USB_Device_Library/Core/inc', platfor
 addi( sf( 'src/platform/%s/FWLib/USB/VCP/inc', platform ) )
 
 local fwlib_files = utils.get_files( "src/platform/" .. platform .. "/FWLib/library/src", ".*%.c$" )
-fwlib_files = fwlib_files .. " " .. utils.get_files( "src/platform/" .. platform .. "/FWLib/USB/", "%.c$" )
+if comp.board ~= "stm32f4-nucleo" then
+  fwlib_files = fwlib_files .. " " .. utils.get_files( "src/platform/" .. platform .. "/FWLib/USB/", "%.c$" )
+end
 specific_files = "system_stm32f4xx.c startup_stm32f4xx.s stm32f4xx_it.c platform.c platform_int.c cpu.c stm32_pio.c enc.c"
-local ldscript = "stm32.ld"
-  
+local ldscript = comp.cpu == "STM32F401RE" and "stm32f401re.ld" or "stm32.ld"
+
 -- Prepend with path
 specific_files = fwlib_files .. " " .. utils.prepend_path( specific_files, "src/platform/" .. platform )
 specific_files = specific_files .. " src/platform/cortex_utils.s src/platform/arm_cortex_interrupts.c"
@@ -20,6 +22,9 @@ ldscript = sf( "src/platform/%s/%s", platform, ldscript )
 addm( { "FOR" .. cnorm( comp.cpu ), "FOR" .. cnorm( comp.board ), 'gcc', 'USE_STDPERIPH_DRIVER', 'STM32F4XX', 'CORTEX_M4' } )
 
 -- Standard GCC Flags
+--delcf( { '-Os' } )
+--addcf( { '-O0' } )
+addcf( { '-g' } )
 addcf( { '-ffunction-sections', '-fdata-sections', '-fno-strict-aliasing', '-Wall' } )
 addlf( { '-nostartfiles','-nostdlib', '-T', ldscript, '-Wl,--gc-sections', '-Wl,--allow-multiple-definition', sf( "-Wl,-Map=%s.map", output ) } )
 addaf( { '-x', 'assembler-with-cpp', '-c', '-Wall' } )

--- a/src/platform/stm32f4/cpu_stm32f401re.h
+++ b/src/platform/stm32f4/cpu_stm32f401re.h
@@ -1,0 +1,52 @@
+// CPU definition file for STM32F401RE
+
+#ifndef __CPU_STM32F401RE_H__
+#define __CPU_STM32F401RE_H__
+
+#include "type.h"
+#include "stacks.h"
+#include "platform_ints.h"
+
+// Number of resources (0 if not available/not implemented)
+#define NUM_PIO               5
+#define NUM_SPI               3
+#define NUM_UART              3
+#define NUM_TIMER             12
+#define NUM_PHYS_TIMER        12
+#define NUM_PWM               4
+#define NUM_ADC               18
+#define NUM_CAN               2
+
+#define ADC_BIT_RESOLUTION    12
+
+u32 platform_s_cpu_get_frequency();
+#define CPU_FREQUENCY         platform_s_cpu_get_frequency()
+
+// PIO prefix ('0' for P0, P1, ... or 'A' for PA, PB, ...)
+#define PIO_PREFIX            'A'
+// Pins per port configuration:
+// #define PIO_PINS_PER_PORT (n) if each port has the same number of pins, or
+// #define PIO_PIN_ARRAY { n1, n2, ... } to define pins per port in an array
+// Use #define PIO_PINS_PER_PORT 0 if this isn't needed
+#define PIO_PINS_PER_PORT     16
+
+// Internal memory data
+#define INTERNAL_SRAM_BASE    0x20000000
+#define INTERNAL_SRAM_SIZE    ( 96 * 1024 )
+#define INTERNAL_RAM1_FIRST_FREE        end
+#define INTERNAL_RAM1_LAST_FREE         ( INTERNAL_SRAM_BASE + INTERNAL_SRAM_SIZE - STACK_SIZE_TOTAL -1 )
+
+// Internal Flash data
+#define INTERNAL_FLASH_SIZE             ( 512 * 1024 )
+#define INTERNAL_FLASH_SECTOR_ARRAY     { 16384, 16384, 16384, 16384, 65536, 131072, 131072, 131072 }
+#define INTERNAL_FLASH_START_ADDRESS    0x08000000
+
+// Interrupt list for this CPU
+#define PLATFORM_CPU_CONSTANTS_INTS\
+  _C( INT_GPIO_POSEDGE ),     \
+  _C( INT_GPIO_NEGEDGE ),     \
+  _C( INT_TMR_MATCH ),        \
+  _C( INT_UART_RX ),
+
+#endif // #ifndef __CPU_STM32F401RE_H__
+

--- a/src/platform/stm32f4/platform.c
+++ b/src/platform/stm32f4/platform.c
@@ -25,10 +25,12 @@
 // Platform specific includes
 #include "stm32f4xx_conf.h"
 #include "pll_config.h"
+#ifdef BUILD_USB_CDC
 #include "usbd_cdc_core.h"
 #include "usbd_usr.h"
 #include "usb_conf.h"
 #include "usbd_desc.h"
+#endif
 
 #define HCLK        ( (HSE_VALUE / PLL_M) * PLL_N / PLL_P)
 #define PCLK1_DIV   4
@@ -959,6 +961,23 @@ static const u8 can_baud_bs1[]    = { CAN_BS1_9tq, CAN_BS1_9tq, CAN_BS1_9tq, CAN
 static const u8 can_baud_bs2[]    = { CAN_BS1_6tq,  CAN_BS1_6tq,  CAN_BS1_6tq, CAN_BS1_6tq, CAN_BS1_3tq };
 static const u8 can_baud_sjw[]    = { CAN_SJW_1tq,  CAN_SJW_1tq,  CAN_SJW_1tq, CAN_SJW_1tq, CAN_SJW_1tq };
 static const u8 can_baud_pre[]    = { 15, 12, 6, 3, 3 };
+
+#endif
+
+#if ELUA_BOARD_CPU_CLOCK_HZ == 84000000
+
+/*       BS1 BS2 SJW Pre
+1M:      13   7   1   1
+500k:    13   7   1   2
+250k:     7   4   1   7
+125k:    15   8   1   7
+100k:    13   7   1  10 */
+
+#define CAN_BAUD_COUNT 5
+static const u8 can_baud_bs1[]    = { CAN_BS1_13tq, CAN_BS1_15tq, CAN_BS1_7tq, CAN_BS1_13tq, CAN_BS1_13tq };
+static const u8 can_baud_bs2[]    = { CAN_BS1_7tq,  CAN_BS1_8tq,  CAN_BS1_4tq, CAN_BS1_7tq,  CAN_BS1_7tq };
+static const u8 can_baud_sjw[]    = { CAN_SJW_1tq,  CAN_SJW_1tq,  CAN_SJW_1tq, CAN_SJW_1tq,  CAN_SJW_1tq };
+static const u8 can_baud_pre[]    = { 10, 7, 7, 2, 1 };
 
 #endif
 

--- a/src/platform/stm32f4/pll_config.h
+++ b/src/platform/stm32f4/pll_config.h
@@ -41,7 +41,11 @@ Restrictions:
 #error PLL_M out of range, unable to compute PLL parameters
 #endif
 
+#if STM32F4_DESIRED_SYSCLK_FREQ_MHZ < 96
+#define PLL_P                                     4
+#else
 #define PLL_P                                     2
+#endif
 #define PLL_N                                     ( STM32F4_DESIRED_SYSCLK_FREQ_MHZ * PLL_P )
 #if PLL_N < 192 || PLL_N > 432
 #error PLL_N out of range, unable to compute PLL parameters

--- a/src/platform/stm32f4/stm32f401re.ld
+++ b/src/platform/stm32f4/stm32f401re.ld
@@ -1,0 +1,70 @@
+MEMORY
+{
+    sram (W!RX) : ORIGIN = 0x20000000, LENGTH = 96K
+    flash (RX) : ORIGIN = 0x08000000, LENGTH = 512K
+}
+
+SECTIONS
+{  
+    .text :
+    {
+        . = ALIGN(4);
+        _text = .;
+        PROVIDE(stext = .);
+        KEEP(*(.isr_vector))
+        *(.text .text.*)        
+        *(.rodata .rodata.*)        
+        *(.gnu.linkonce.t.*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.gcc_except_table)
+        *(.gnu.linkonce.r.*)
+        . = ALIGN(4);
+        _etext = .;
+		_sidata = _etext;
+        PROVIDE(etext = .);   
+     		_fini = . ;
+				*(.fini)
+
+    } >flash
+
+    .data : AT (_etext)
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.ramfunc .ramfunc.* .fastrun .fastrun.*)
+        *(.data .data.*)
+        *(.gnu.linkonce.d.*)
+        . = ALIGN(4);
+        _edata = .;
+    } >sram
+		
+		.ARM.extab :
+		{
+		    *(.ARM.extab*)
+		} >sram
+		
+		__exidx_start = .;
+		.ARM.exidx :
+		{
+		    *(.ARM.exidx*)
+		} >sram
+		__exidx_end = .;
+
+    PROVIDE( flash_used_size = SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.ARM.extab) + SIZEOF(.ARM.exidx) );
+		
+    .bss (NOLOAD) : {
+		. = ALIGN(4);
+        /* This is used by the startup in order to initialize the .bss secion */
+        _sbss = .;
+        *(.bss .bss.*)
+        *(.gnu.linkonce.b.*)
+        *(COMMON)
+        . = ALIGN(4);        
+        _ebss = .;
+    } >sram
+    
+    end = .;
+    PROVIDE( _estack = 0x20018000 );
+}
+

--- a/src/platform/stm32f4/system_stm32f4xx.c
+++ b/src/platform/stm32f4/system_stm32f4xx.c
@@ -333,9 +333,14 @@ static void SetSysClock(void)
 /*            PLL (clocked by HSE) used as System clock source                */
 /******************************************************************************/
   __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
-  
+
+#ifdef FORSTM32F4NUCLEO
+  /* Enable HSE bypass as board provides external 8MHz clock to MCU */
+  RCC->CR |= ((uint32_t)RCC_CR_HSEBYP);
+#else
   /* Enable HSE */
   RCC->CR |= ((uint32_t)RCC_CR_HSEON);
+#endif
  
   /* Wait till HSE is ready and if Time out is reached exit */
   do


### PR DESCRIPTION
The Nucleo boards are like the Discovery boards in that they come with an
attached STLINK-V2 programmer. The MCU's UART2 is routed through the
programmer's USB connection and it appears as a VCP device on the host.

So far, this has only been tested to the extent that the elua shell and
lua prompt appear to be functioning as expected.
