### PR TITLE
Stm32f4 nucleo

### DIFF
--- a/boards/known/stm32f4-nucleo.lua
+++ b/boards/known/stm32f4-nucleo.lua
@@ -20,7 +20,7 @@ return {
     egc = { mode = "alloc" },
     vtmr = { num = 4, freq = 10 },
     ram = { internal_rams = 1 },
-    clocks = { external = 16000000, cpu = 84000000 },
+    clocks = { internal = 16000000, cpu = 84000000 },
     stm32f4_uart_pins = { con_rx_port = 0, con_rx_pin = 3, con_tx_port = 0, con_tx_pin = 2 }
   },
   modules = {

--- a/src/platform/stm32f4/build_config.lua
+++ b/src/platform/stm32f4/build_config.lua
@@ -22,6 +22,7 @@ function add_platform_configs( t, board, cpu )
     },
     required = { con_rx_port = 1, con_rx_pin = 7, con_tx_port = 1, con_tx_pin = 6 }
   }
+  t.clocks.attrs.internal = at.make_optional( at.int_attr( 'ELUA_BOARD_INTERNAL_CLOCK_HZ', 1 ) )
 end
 
 -- Return an array of all the available platform modules for the given cpu

--- a/src/platform/stm32f4/platform_generic.h
+++ b/src/platform/stm32f4/platform_generic.h
@@ -3,6 +3,16 @@
 #ifndef __PLATFORM_GENERIC_H__
 #define __PLATFORM_GENERIC_H__
 
+#if defined(ELUA_BOARD_EXTERNAL_CLOCK_HZ)
+ #if defined(ELUA_BOARD_INTERNAL_CLOCK_HZ)
+  #error You must not specify both external and internal clock frequencies in 'clocks = { ... }'
+ #endif
+#elif defined(ELUA_BOARD_INTERNAL_CLOCK_HZ)
+ #define ELUA_BOARD_EXTERNAL_CLOCK_HZ ELUA_BOARD_INTERNAL_CLOCK_HZ
+#else
+ #error You must specify either an external or internal clock frequency in 'clocks = { ... }'
+#endif
+
 #define PLATFORM_HAS_SYSTIMER
 #define ENABLE_JTAG_SWD
 

--- a/src/platform/stm32f4/system_stm32f4xx.c
+++ b/src/platform/stm32f4/system_stm32f4xx.c
@@ -332,9 +332,8 @@ static void SetSysClock(void)
 /******************************************************************************/
 /*            PLL (clocked by HSE) used as System clock source                */
 /******************************************************************************/
-#ifdef FORSTM32F4NUCLEO
-  // by default, the STM32F4 Nucleo board doesn't have an external crystal
-  // or clock source attached to the F4 so use the HSI clock instead
+#ifdef ELUA_BOARD_INTERNAL_CLOCK_HZ
+  // we're using the HSI clock so just fake HSE good status
   uint32_t HSEStatus = 0x01;
 #else
   __IO uint32_t StartUpCounter = 0, HSEStatus = 0;
@@ -375,7 +374,7 @@ static void SetSysClock(void)
     RCC->CFGR |= RCC_CFGR_PPRE1_DIV4;
 
     /* Configure the main PLL */
-#ifdef FORSTM32F4NUCLEO
+#ifdef ELUA_BOARD_INTERNAL_CLOCK_HZ
     RCC->PLLCFGR = PLL_M | (PLL_N << 6) | (((PLL_P >> 1) -1) << 16) |
                    (RCC_PLLCFGR_PLLSRC_HSI) | (PLL_Q << 24);
 #else


### PR DESCRIPTION
It turns out that as supplied, the Nucleo board doesn't provide the MCU with an external clock so these commits add an "internal" clock frequency attribute that you can use in the board configuration file to specify that the internal clock is to be used and what its frequency is.

Also, the number of wait states required when accessing the flash memory is optimised to match the system clock rate.
