### PR TITLE
STM32F4 - TCK/SWDCLK should be pulled down, not up.

### DIFF
--- a/src/platform/stm32f4/platform.c
+++ b/src/platform/stm32f4/platform.c
@@ -225,7 +225,7 @@ static void pios_init()
   GPIO_PinAFConfig(GPIOA, GPIO_PinSource14, GPIO_AF_SWJ); // PA14 TCK   / SWDCLK
   GPIO_PinAFConfig(GPIOA, GPIO_PinSource15, GPIO_AF_SWJ); // PA15 TDI
 
-  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13 | GPIO_Pin_14 | GPIO_Pin_15;
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13 | GPIO_Pin_15;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
   GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
@@ -234,6 +234,11 @@ static void pios_init()
 
   GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3 | GPIO_Pin_4;
   GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_14;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_DOWN;
+  GPIO_Init(GPIOA, &GPIO_InitStructure);
+
 #endif
 
 #ifdef ENABLE_TRACE


### PR DESCRIPTION
Convention has it that TCK/SWDCLK is pulled down rather than up so bring the STM32F4 code into line. Does it really matter anyway?
