### PR TITLE
Fix build for MBED, add initial support for LPCXpresso LPC1769

### DIFF
--- a/boards/known/lpcxpresso.lua
+++ b/boards/known/lpcxpresso.lua
@@ -1,0 +1,26 @@
+-- LPCXpresso LPC1769 build configuration
+
+return {
+  cpu = 'lpc1769',
+  components = {
+    sercon = { uart = 0, speed = 115200 },
+    romfs = true,
+    shell = true,
+    term = { lines = 25, cols = 80 },
+    linenoise = { shell_lines = 10, lua_lines = 50 },
+    rpc = { uart = 0, speed = 115200 },
+    adc = { buf_size = 4 },
+    xmodem = true,
+    lpc17xx_semifs = true
+  },
+  config = {
+    egc = { mode = "alloc" },
+    ram = { internal_rams = 2 }
+  },
+  modules = {
+    generic = { 'all', "-spi", "-i2c", "-net" },
+    platform = 'all',
+    platform_name = 'lpcxpresso'
+  },
+}
+

--- a/build_data.lua
+++ b/build_data.lua
@@ -114,7 +114,7 @@ local platform_list =
   stm32f4 = { cpus =  { 'STM32F411RE', 'STM32F401RE', 'STM32F407VG', 'STM32F407ZG' }, arch = 'cortexm' },
   avr32 = { cpus = { 'AT32UC3A0128', 'AT32UC3A0256', 'AT32UC3A0512', 'AT32UC3B0256' }, arch = 'avr32' },
   lpc24xx = { cpus = { 'LPC2468' }, arch = 'arm' },
-  lpc17xx = { cpus = { 'LPC1768' }, arch = 'cortexm' }
+  lpc17xx = { cpus = { 'LPC1768', 'LPC1769' }, arch = 'cortexm' }
 }
 
 -- Returns the platform of a given CPU

--- a/src/platform/lpc17xx/cpu_lpc1769.h
+++ b/src/platform/lpc17xx/cpu_lpc1769.h
@@ -1,0 +1,43 @@
+// eLua platform configuration
+
+#ifndef __CPU_LPC1769_H__
+#define __CPU_LPC1769_H__
+
+#include "stacks.h"
+
+// Number of resources (0 if not available/not implemented)
+#define NUM_PIO               5
+#define NUM_SPI               0
+#define NUM_UART              4
+#define NUM_PWM               6
+#define NUM_ADC               8
+#define NUM_CAN               2
+#define NUM_TIMER             4
+
+#define ADC_BIT_RESOLUTION    12
+
+// CPU frequency (needed by the CPU module, 0 if not used)
+u32 mbed_get_cpu_frequency();
+#define CPU_FREQUENCY         mbed_get_cpu_frequency()
+
+// PIO prefix ('0' for P0, P1, ... or 'A' for PA, PB, ...)
+#define PIO_PREFIX            '0'
+// Pins per port configuration:
+// #define PIO_PINS_PER_PORT (n) if each port has the same number of pins, or
+// #define PIO_PIN_ARRAY { n1, n2, ... } to define pins per port in an array
+// Use #define PIO_PINS_PER_PORT 0 if this isn't needed
+#define PIO_PINS_PER_PORT     32
+
+// Allocator data: define your free memory zones here in two arrays
+// (start address and end address)
+#define SRAM_ORIGIN           0x10000000
+#define SRAM_SIZE             0x8000
+#define SRAM2_ORIGIN          0x2007C000
+#define SRAM2_SIZE            0x8000
+#define INTERNAL_RAM1_FIRST_FREE  end
+#define INTERNAL_RAM1_LAST_FREE   ( SRAM_ORIGIN + SRAM_SIZE - STACK_SIZE_TOTAL - 1 )
+#define INTERNAL_RAM2_FIRST_FREE  SRAM2_ORIGIN 
+#define INTERNAL_RAM2_LAST_FREE   ( SRAM2_ORIGIN + SRAM2_SIZE - 1 )
+ 
+#endif // #ifndef __CPU_LPC1769_H__
+

--- a/src/platform/lpc17xx/drivers/inc/lpc_types.h
+++ b/src/platform/lpc17xx/drivers/inc/lpc_types.h
@@ -32,17 +32,12 @@
 
 /* Includes ------------------------------------------------------------------- */
 #include <stdint.h>
-
+#include <type.h>
 
 /* Public Types --------------------------------------------------------------- */
 /** @defgroup LPC_Types_Public_Types
  * @{
  */
-
-/**
- * @brief Boolean Type definition
- */
-typedef enum {FALSE = 0, TRUE = !FALSE} Bool;
 
 /**
  * @brief Flag Status and Interrupt Flag Status type definition

--- a/src/platform/lpc17xx/type.h
+++ b/src/platform/lpc17xx/type.h
@@ -19,5 +19,7 @@ typedef unsigned int   BOOL;
 
 typedef volatile unsigned long* PREG;
 
+typedef enum {FALSE = 0, TRUE = !FALSE} Bool;
+
 #endif
 


### PR DESCRIPTION
I guess due to bitrot, compilation for MBED stopped working. Moving around the definition of Bool seems to help.

Also, initial support for the LPCXpresso LPC1769, which is in fact very similar to the MBED. Got the LED blinking from Lua, next step is getting console access up and running.