### PR TITLE
XMC4500 SDRAM bootkit: Initial port

### DIFF
--- a/boards/known/xmc4500-hexagon-sdram.lua
+++ b/boards/known/xmc4500-hexagon-sdram.lua
@@ -1,0 +1,42 @@
+
+-- Infineon XMC4500 Hexagon SDRAM boot-kit build configuration
+
+--[[
+
+Notes:
+
+1) This XMC4000 board has the XMC4500E144K1024 chip (BGA package).
+
+2) While this XMC4500 also has its own SDMMC peripheral, we can't use
+   the hardware SDMMC pins because some of the data lines are used to
+   talk to the ISSI SDRAM controller. So, on this board, it is all
+   about SDRAM. To have an SD card interface, SPI is the only way.
+
+--]]
+
+
+return {
+  cpu = 'xmc4500e144k1024',
+  components = {
+    sercon = { uart = 0, speed = 115200 },
+    xmc45_pot = true,
+    xmc45_dts = true,
+    xmc45_rtc = true,
+    xmc45_disp = false,
+    wofs = false,
+    romfs = true,
+    mmcfs = { spi = 0, cs_port = 0, cs_pin = 0 },
+    shell = true,
+    term = { lines = 25, cols = 80 },
+    linenoise = { shell_lines = 10, lua_lines = 50 },
+    xmodem = false
+  },
+  config = {
+    egc = { mode = "alloc" },
+    ram = { internal_rams = 3 },
+  },
+  modules = {
+    generic = { 'all', '-i2c', '-net', '-adc', '-spi', '-uart', '-can', '-pwm', '-rpc' },
+    platform = 'all',
+  }
+}

--- a/build_data.lua
+++ b/build_data.lua
@@ -116,7 +116,7 @@ local platform_list =
   lpc23xx = { cpus = { 'LPC2368' }, arch = 'arm' },
   lpc24xx = { cpus = { 'LPC2468' }, arch = 'arm' },
   lpc17xx = { cpus = { 'LPC1768' }, arch = 'cortexm' },
-  xmc4000 = { cpus = { 'XMC4500F144K1024', 'XMC4700F144K2048' }, arch = 'cortexm' },
+  xmc4000 = { cpus = { 'XMC4500F144K1024', 'XMC4500E144K1024', 'XMC4700F144K2048' }, arch = 'cortexm' },
 }
 
 -- Returns the platform of a given CPU

--- a/src/elua_mmc.c
+++ b/src/elua_mmc.c
@@ -6,7 +6,7 @@
 // web site by Jesus Alvarez & James Snyder for eLua.
  
 #include "platform_conf.h"
-#if defined( BUILD_MMCFS ) && !defined( ELUA_SIMULATOR ) && !defined( XMC4500_F144x1024 ) && !defined( XMC4700_F144x2048 )
+#if defined( BUILD_MMCFS ) && !defined( ELUA_SIMULATOR ) && !defined( XMC4500_F144x1024 ) && !defined( XMC4500_E144x1024 ) && !defined( XMC4700_F144x2048 )
 #include "platform.h"
 #include "diskio.h"
 #include "mmcfs.h"

--- a/src/platform/xmc4000/build_config.lua
+++ b/src/platform/xmc4000/build_config.lua
@@ -18,7 +18,7 @@ local at = require "attributes"
 -- Add specific components to the 'components' table
 function add_platform_components( t, board, cpu )
   board = board:upper()
-  if board == 'XMC4500-HEXAGON' then
+  if board == 'XMC4500-HEXAGON' or board == 'XMC4500-HEXAGON-SDRAM' then
     t.xmc45_pot = { macro = 'ENABLE_POTENTIOMETER' }
     t.xmc45_dts = { macro = 'ENABLE_DTS' }
     t.xmc45_rtc = { macro = 'ENABLE_RTC' }
@@ -35,7 +35,7 @@ end
 function get_platform_modules( board, cpu )
   m = { }
   board = board:upper()
-  if board == 'XMC4500-HEXAGON' then
+  if board == 'XMC4500-HEXAGON' or board == 'XMC4500-HEXAGON' then
     m.pot = { guards = { 'ENABLE_POTENTIOMETER' }, lib = '"pot"', open = false }
     m.dts = { guards = { 'ENABLE_DTS' }, lib = '"dts"', open = false }
     m.rtc = { guards = { 'ENABLE_RTC' }, lib = '"rtc"', open = false }

--- a/src/platform/xmc4000/conf.lua
+++ b/src/platform/xmc4000/conf.lua
@@ -7,7 +7,7 @@ local ldscript = ""
 local target_files = ""
 local cpu = comp.cpu:upper()
 
-if cpu == 'XMC4500F144K1024' then
+if cpu == 'XMC4500F144K1024' or cpu == 'XMC4500E144K1024' then
   ldscript = "xmc4500_linker_script.ld"
   target_files = " startup_XMC4500.S system_XMC4500.c"
 end
@@ -42,6 +42,10 @@ addm( { "FOR" .. cnorm( comp.cpu ), "FOR" .. cnorm( comp.board ), 'gcc', 'CORTEX
 
 if cpu == 'XMC4500F144K1024' then
   addm( { "XMC4500_F144x1024" } )
+end
+
+if cpu == 'XMC4500E144K1024' then
+  addm( { "XMC4500_E144x1024" } )
 end
 
 if cpu == 'XMC4700F144K2048' then

--- a/src/platform/xmc4000/cpu_xmc4500e144k1024.h
+++ b/src/platform/xmc4000/cpu_xmc4500e144k1024.h
@@ -1,0 +1,42 @@
+
+#ifndef __CPU_XMC4500E144K1024_H__
+#define __CPU_XMC4500E144K1024_H__
+
+#include "stacks.h"
+
+// Number of resources (0 if not available/not implemented)
+#define NUM_PIO               16
+#define NUM_SPI               0
+#define NUM_UART              1
+#define NUM_TIMER             1
+#define NUM_PWM               0
+#define NUM_ADC               0
+#define NUM_CAN               0
+
+// CPU frequency (needed by the CPU module and MMCFS code, 0 if not used)
+#define CPU_FREQUENCY         120000000
+
+// PIO prefix ('0' for P0, P1, ... or 'A' for PA, PB, ...)
+#define PIO_PREFIX            '0'
+// Pins per port configuration:
+// #define PIO_PINS_PER_PORT (n) if each port has the same number of pins, or
+// #define PIO_PIN_ARRAY { n1, n2, ... } to define pins per port in an array
+// Use #define PIO_PINS_PER_PORT 0 if this isn't needed
+#define PIO_PIN_ARRAY         { 16, 16, 16, 16, 8, 12, 7, 0, 0, 0, 0, 0, 0, 0, 14, 12 }
+
+// Allocator data: define your free memory zones here in two arrays
+// (start address and end address)
+#define DSRAM1_SIZE           ( 64 * 1024 )
+#define DSRAM1_BASE           0x20000000
+#define DSRAM2_SIZE           ( 32 * 1024 )
+#define DSRAM2_BASE           0x30000000
+#define PSRAM_SIZE            ( 64 * 1024 )
+#define PSRAM_BASE            0x10000000
+#define INTERNAL_RAM1_FIRST_FREE end
+#define INTERNAL_RAM1_LAST_FREE  ( DSRAM1_BASE + DSRAM1_SIZE - STACK_SIZE_TOTAL - 1 )
+#define INTERNAL_RAM2_FIRST_FREE DSRAM2_BASE
+#define INTERNAL_RAM2_LAST_FREE  ( DSRAM2_BASE + DSRAM2_SIZE - 1 )
+#define INTERNAL_RAM3_FIRST_FREE PSRAM_BASE
+#define INTERNAL_RAM3_LAST_FREE  ( PSRAM_BASE + PSRAM_SIZE - 1 )
+
+#endif // #ifndef __CPU_XMC4500E144K1024_H__


### PR DESCRIPTION

The XMC4500_E144x1024 is the same as XMC4500_F144x1024. The RAM and peripheral
configurations work out of the box. We connect the SDRAM sections to eLua later.