### PR TITLE
stm32f4 compiler warning fixes

### DIFF
--- a/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/inc/usbd_req.h
+++ b/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/inc/usbd_req.h
@@ -89,7 +89,7 @@ void USBD_ParseSetupRequest( USB_OTG_CORE_HANDLE  *pdev,
 void USBD_CtlError( USB_OTG_CORE_HANDLE  *pdev,
                             USB_SETUP_REQ *req);
 
-void USBD_GetString(uint8_t *desc, uint8_t *unicode, uint16_t *len);
+void USBD_GetString(const char *desc, uint8_t *unicode, uint16_t *len);
 /**
   * @}
   */ 

--- a/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/src/usbd_req.c
+++ b/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/src/usbd_req.c
@@ -127,7 +127,7 @@ static void USBD_SetFeature(USB_OTG_CORE_HANDLE  *pdev,
 static void USBD_ClrFeature(USB_OTG_CORE_HANDLE  *pdev, 
                             USB_SETUP_REQ *req);
 
-static uint8_t USBD_GetLen(uint8_t *buf);
+static uint8_t USBD_GetLen(const char *buf);
 /**
   * @}
   */ 
@@ -815,7 +815,7 @@ void USBD_CtlError( USB_OTG_CORE_HANDLE  *pdev,
   * @param  len : descriptor length
   * @retval None
   */
-void USBD_GetString(uint8_t *desc, uint8_t *unicode, uint16_t *len)
+void USBD_GetString(const char *desc, uint8_t *unicode, uint16_t *len)
 {
   uint8_t idx = 0;
   
@@ -839,7 +839,7 @@ void USBD_GetString(uint8_t *desc, uint8_t *unicode, uint16_t *len)
    * @param  buf : pointer to the ascii string buffer
   * @retval string length
   */
-static uint8_t USBD_GetLen(uint8_t *buf)
+static uint8_t USBD_GetLen(const char *buf)
 {
     uint8_t  len = 0;
 

--- a/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/src/usbd_req.c
+++ b/src/platform/stm32f4/FWLib/USB/STM32_USB_Device_Library/Core/src/usbd_req.c
@@ -825,7 +825,7 @@ void USBD_GetString(uint8_t *desc, uint8_t *unicode, uint16_t *len)
     unicode[idx++] = *len;
     unicode[idx++] =  USB_DESC_TYPE_STRING;
     
-    while (*desc != NULL) 
+    while (*desc != '\0') 
     {
       unicode[idx++] = *desc++;
       unicode[idx++] =  0x00;
@@ -843,7 +843,7 @@ static uint8_t USBD_GetLen(uint8_t *buf)
 {
     uint8_t  len = 0;
 
-    while (*buf != NULL) 
+    while (*buf != '\0') 
     {
         len++;
         buf++;

--- a/src/platform/stm32f4/FWLib/USB/VCP/src/usbd_cdc_vcp.c
+++ b/src/platform/stm32f4/FWLib/USB/VCP/src/usbd_cdc_vcp.c
@@ -64,7 +64,6 @@ static uint16_t VCP_Ctrl     (uint32_t Cmd, uint8_t* Buf, uint32_t Len);
 uint16_t VCP_DataTx   (uint8_t* Buf, uint32_t Len);
 static uint16_t VCP_DataRx   (uint8_t* Buf, uint32_t Len);
 
-static uint16_t VCP_COMConfig(uint8_t Conf);
 
 CDC_IF_Prop_TypeDef VCP_fops = 
 {

--- a/src/platform/stm32f4/enc.c
+++ b/src/platform/stm32f4/enc.c
@@ -63,7 +63,7 @@ static int enc_set_index_handler( lua_State *L )
 static void index_handler( elua_int_resnum resnum )
 {
   if( prev_handler )
-    prev_handler;
+    prev_handler( resnum );
 
   if( resnum != index_resnum )
     return;

--- a/src/platform/stm32f4/usb_conf.h
+++ b/src/platform/stm32f4/usb_conf.h
@@ -252,8 +252,10 @@
   #define __packed    __packed
 #elif defined (__ICCARM__)     /* IAR Compiler */
   #define __packed    __packed
-#elif defined   ( __GNUC__ )   /* GNU Compiler */                        
-  #define __packed    __attribute__ ((__packed__))
+#elif defined   ( __GNUC__ )   /* GNU Compiler */ 
+  #ifndef __packed                       
+    #define __packed    __attribute__ ((__packed__))
+  #endif
 #elif defined   (__TASKING__)  /* TASKING Compiler */
   #define __packed    __unaligned
 #endif /* __CC_ARM */


### PR DESCRIPTION
This fixes several compiler warnings and also fixes a bug in enc.c where prev_handler wasn't being called.
These issues probably exist in stm32 and stm32f2 as well but I only fixed them in stm32f4 as that is the platform I have and am working on.