### PR TITLE
XMC4500 proto-card-v2: Add initial eLua support

### DIFF
--- a/boards/known/xmc4500-protocard-v2.lua
+++ b/boards/known/xmc4500-protocard-v2.lua
@@ -27,7 +27,6 @@ return {
     xmc45_disp = true,
     wofs = false,
     romfs = true,
-    mmcfs = { spi = 0, cs_port = 0, cs_pin = 0 },
     shell = true,
     term = { lines = 25, cols = 80 },
     linenoise = { shell_lines = 10, lua_lines = 50 },

--- a/boards/known/xmc4500-protocard-v2.lua
+++ b/boards/known/xmc4500-protocard-v2.lua
@@ -1,0 +1,44 @@
+
+-- Infineon XMC4500 prototype card v2 build configuration
+
+--[[
+
+Notes:
+
+1) This particular target doesn't have any on-board peripherals. The
+   board can be used to talk to the Maxon BLDC interface. OR toggle a
+   few LEDS from eLua. OR play terminal games.
+
+2) No SDMMC. That makes me sad! :(
+
+3) The fun part about this particular board is that it is very tiny. I
+   like to call it "pocket eLua" in the context of this target.
+
+--]]
+
+
+return {
+  cpu = 'xmc4500f144k1024',
+  components = {
+    sercon = { uart = 0, speed = 115200 },
+    xmc45_pot = true,
+    xmc45_dts = true,
+    xmc45_rtc = true,
+    xmc45_disp = true,
+    wofs = false,
+    romfs = true,
+    mmcfs = { spi = 0, cs_port = 0, cs_pin = 0 },
+    shell = true,
+    term = { lines = 25, cols = 80 },
+    linenoise = { shell_lines = 10, lua_lines = 50 },
+    xmodem = false
+  },
+  config = {
+    egc = { mode = "alloc" },
+    ram = { internal_rams = 3 },
+  },
+  modules = {
+    generic = { 'all', '-i2c', '-net', '-adc', '-spi', '-uart', '-can', '-pwm', '-rpc' },
+    platform = 'all',
+  }
+}

--- a/src/platform/xmc4000/build_config.lua
+++ b/src/platform/xmc4000/build_config.lua
@@ -18,7 +18,9 @@ local at = require "attributes"
 -- Add specific components to the 'components' table
 function add_platform_components( t, board, cpu )
   board = board:upper()
-  if board == 'XMC4500-HEXAGON' or board == 'XMC4500-HEXAGON-SDRAM' then
+  if board == 'XMC4500-HEXAGON' or
+     board == 'XMC4500-HEXAGON-SDRAM' or
+     board == 'XMC4500-PROTOCARD-V2' then
     t.xmc45_pot = { macro = 'ENABLE_POTENTIOMETER' }
     t.xmc45_dts = { macro = 'ENABLE_DTS' }
     t.xmc45_rtc = { macro = 'ENABLE_RTC' }


### PR DESCRIPTION

XMC4500 proto-card-v2: Add initial eLua support.

P.S. I really want everyone to have a "pocket eLua" :)