### PR TITLE
SDMMC: Correct CS pin to resolve access to SD card

### DIFF
--- a/boards/known/elua-zeisig-gemacht.lua
+++ b/boards/known/elua-zeisig-gemacht.lua
@@ -20,7 +20,7 @@ R
 return {
   cpu = 'stm32f103vct6',
   components = {
-    mmcfs = { spi = 0, cs_port = 4, cs_pin = 0 },
+    mmcfs = { spi = 0, cs_port = 0, cs_pin = 4 },
     sercon = { uart = 0, speed = 115200, buf_size = 128 },
     wofs = false,
     romfs = false,


### PR DESCRIPTION

Corrected SPI's port and CS pin. `ls' can now see the files in the SD card.

R

P.S. Time for some games :)