### PR TITLE
Additional patches to eLua

### DIFF
--- a/inc/xmodem.h
+++ b/inc/xmodem.h
@@ -7,8 +7,8 @@
 #include "platform.h"
 
 // XMODEM constants
-#define XMODEM_INITIAL_BUFFER_SIZE    1024
-#define XMODEM_INCREMENT_AMMOUNT      512
+#define XMODEM_INITIAL_BUFFER_SIZE    4096 // TH
+#define XMODEM_INCREMENT_AMMOUNT      4096 // TH
 
 // xmodem timeout/retry parameters
 #define XMODEM_TIMEOUT                1000000
@@ -19,6 +19,7 @@
 #define XMODEM_ERROR_OUTOFSYNC        (-2)
 #define XMODEM_ERROR_RETRYEXCEED      (-3)
 #define XMODEM_ERROR_OUTOFMEM         (-4)
+#define XMODEM_ERROR_INTERNAL         (-5) // TH
 
 typedef void ( *p_xm_send_func )( u8 );
 typedef int ( *p_xm_recv_func )( timer_data_type );

--- a/src/lua/lauxlib.c
+++ b/src/lua/lauxlib.c
@@ -654,7 +654,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
-    lf.extraline = 0;
+   lf.extraline = 0;
   }
   ungetc(c, lf.f);
   if (srcp) {

--- a/src/lua/ltablib.c
+++ b/src/lua/ltablib.c
@@ -138,7 +138,7 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
   if (!lua_isstring(L, -1))
     luaL_error(L, "invalid value (%s) at index %d in table for "
                   LUA_QL("concat"), luaL_typename(L, -1), i);
-    luaL_addvalue(b);
+  luaL_addvalue(b);
 }
 
 

--- a/src/modules/bit.c
+++ b/src/modules/bit.c
@@ -14,12 +14,21 @@
 #include "lrotable.h"
 
 /* FIXME: Assume size_t is an unsigned lua_Integer */
-typedef size_t lua_UInteger;
+typedef u32 lua_UInteger;
 #define LUA_UINTEGER_MAX SIZE_MAX
+
+
+//TH: Local Push unsigned integer
+void  bit_pushuinteger(lua_State *L, lua_UInteger n)
+{
+	
+	lua_pushnumber( L, ( lua_Number )n);
+	
+}	
 
 /* Define TOBIT to get a bit value */
 #define TOBIT(L, n)                    \
-  (luaL_checkinteger((L), (n)))
+  ((lua_UInteger)luaL_checknumber((L), (n)))
 
 /* Operations
 
@@ -35,30 +44,30 @@ typedef size_t lua_UInteger;
   
 #define MONADIC(name, op)                                       \
   static int bit_ ## name(lua_State *L) {                       \
-    lua_pushinteger(L, op TOBIT(L, 1));                         \
+    bit_pushuinteger(L, op TOBIT(L, 1));                         \
     return 1;                                                   \
   }
 
 #define VARIADIC(name, op)                      \
   static int bit_ ## name(lua_State *L) {       \
     int n = lua_gettop(L), i;                   \
-    lua_Integer w = TOBIT(L, 1);                \
+    lua_UInteger w = TOBIT(L, 1);                \
     for (i = 2; i <= n; i++)                    \
       w op TOBIT(L, i);                         \
-    lua_pushinteger(L, w);                      \
+    bit_pushuinteger(L, w);                      \
     return 1;                                   \
   }
 
 #define LOGICAL_SHIFT(name, op)                                         \
   static int bit_ ## name(lua_State *L) {                               \
-    lua_pushinteger(L, (lua_UInteger)TOBIT(L, 1) op                     \
+    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                     \
                           (unsigned)luaL_checknumber(L, 2));            \
     return 1;                                                           \
   }
 
 #define ARITHMETIC_SHIFT(name, op)                                      \
   static int bit_ ## name(lua_State *L) {                               \
-    lua_pushinteger(L, (lua_Integer)TOBIT(L, 1) op                      \
+    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                      \
                           (unsigned)luaL_checknumber(L, 2));            \
     return 1;                                                           \
   }
@@ -74,14 +83,14 @@ ARITHMETIC_SHIFT(arshift, >>)
 // Lua: res = bit( position )
 static int bit_bit( lua_State* L )
 {
-  lua_pushinteger( L, ( lua_Integer )( 1 << luaL_checkinteger( L, 1 ) ) );
+  bit_pushuinteger( L, ( lua_UInteger )( 1 << luaL_checkinteger( L, 1 ) ) );
   return 1;
 }
 
 // Lua: res = isset( value, position )
 static int bit_isset( lua_State* L )
 {
-  lua_UInteger val = ( lua_UInteger )luaL_checkinteger( L, 1 );
+  lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned pos = ( unsigned )luaL_checkinteger( L, 2 );
   
   lua_pushboolean( L, val & ( 1 << pos ) ? 1 : 0 );
@@ -91,7 +100,7 @@ static int bit_isset( lua_State* L )
 // Lua: res = isclear( value, position )
 static int bit_isclear( lua_State* L )
 {
-  lua_UInteger val = ( lua_UInteger )luaL_checkinteger( L, 1 );
+  lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned pos = ( unsigned )luaL_checkinteger( L, 2 );
   
   lua_pushboolean( L, val & ( 1 << pos ) ? 0 : 1 );
@@ -101,24 +110,24 @@ static int bit_isclear( lua_State* L )
 // Lua: res = set( value, pos1, pos2, ... )
 static int bit_set( lua_State* L )
 { 
-  lua_UInteger val = ( lua_UInteger )luaL_checkinteger( L, 1 );
+  lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned total = lua_gettop( L ), i;
   
   for( i = 2; i <= total; i ++ )
     val |= 1 << ( unsigned )luaL_checkinteger( L, i );
-  lua_pushinteger( L, ( lua_Integer )val );
+  bit_pushuinteger( L, ( lua_UInteger )val );
   return 1;
 }
 
 // Lua: res = clear( value, pos1, pos2, ... )
 static int bit_clear( lua_State* L )
 {
-  lua_UInteger val = ( lua_UInteger )luaL_checkinteger( L, 1 );
+  lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned total = lua_gettop( L ), i;
   
   for( i = 2; i <= total; i ++ )
     val &= ~( 1 << ( unsigned )luaL_checkinteger( L, i ) );
-  lua_pushinteger( L, ( lua_Integer )val );
+  bit_pushuinteger( L, ( lua_UInteger )val );
   return 1; 
 }
 

--- a/src/modules/bit.c
+++ b/src/modules/bit.c
@@ -5,12 +5,15 @@
 // Modified by BogdanM for eLua
 
 // TH: Fixed various places to do all conversions to/from lua numbers as unsigned
-// This is also consitent with other parts of eLua  e.g. the cpu module
-// If have also considered using signed integers like in http://bitop.luajit.org/
-// This would have the advantage that the behaviour for lua "long" would be
-// identical to lua "double".  But it also a lot of drawbacks, and would be inconsistent
-// with e.g. the cpu.r/w operations, because they expect unsigned numbers.
-//   
+// TH 08.08.2017: Changed the patch now in a way that the bit module behaves similar
+// to the bit32 module in lua 5.2: All numbers passed to the bit functions are
+// "downscaled" to the 2^32 range.
+// In this way the module accepts "unsigned" and "signed" numbers and handle
+// them in the right way.
+// So print(bit.tohex(2^32-1)), print(bit.tohex(0xffffffff) and
+// print(bit.tohex(-1)) will all return the same result "ffffffff"
+
+
 // In addtion I added the tohex and rotate functions from http://bitop.luajit.org/
 
 
@@ -30,14 +33,14 @@ typedef u32 lua_UInteger;
 //TH: Local Push unsigned integer
 void  bit_pushuinteger(lua_State *L, lua_UInteger n)
 {
-	
-	lua_pushnumber( L, ( lua_Number )n);
-	
-}	
+
+  lua_pushnumber( L, ( lua_Number )n);
+
+}
 
 /* Define TOBIT to get a bit value */
 #define TOBIT(L, n)                    \
-  ((lua_UInteger)luaL_checknumber((L), (n)))
+  ( ( (s64)luaL_checknumber((L), (n))) & 0x0ffffffff  )
 
 /* Operations
 
@@ -50,47 +53,52 @@ void  bit_pushuinteger(lua_State *L, lua_UInteger n)
    ARITHMETIC_SHIFT does not truncate its left-hand operand, so that
    the sign bits are not removed and right shift work properly.
    */
-  
+
 #define MONADIC(name, op)                                       \
   static int bit_ ## name(lua_State *L) {                       \
-    bit_pushuinteger(L, op TOBIT(L, 1));                         \
+    bit_pushuinteger(L, op TOBIT(L, 1));                        \
     return 1;                                                   \
   }
 
 #define VARIADIC(name, op)                      \
   static int bit_ ## name(lua_State *L) {       \
     int n = lua_gettop(L), i;                   \
-    lua_UInteger w = TOBIT(L, 1);                \
+    lua_UInteger w = TOBIT(L, 1);               \
     for (i = 2; i <= n; i++)                    \
       w op TOBIT(L, i);                         \
-    bit_pushuinteger(L, w);                      \
+    bit_pushuinteger(L, w);                     \
     return 1;                                   \
   }
 
 #define LOGICAL_SHIFT(name, op)                                         \
   static int bit_ ## name(lua_State *L) {                               \
-    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                     \
+    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                    \
                           (unsigned)luaL_checknumber(L, 2));            \
     return 1;                                                           \
   }
 
 #define ARITHMETIC_SHIFT(name, op)                                      \
   static int bit_ ## name(lua_State *L) {                               \
-    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                      \
+    bit_pushuinteger(L, (lua_UInteger)TOBIT(L, 1) op                    \
                           (unsigned)luaL_checknumber(L, 2));            \
     return 1;                                                           \
   }
-  
-// Added TH  
-#define BIT_SH(name, fn)                                      \
-  static int bit_ ## name(lua_State *L) {                               \
-    bit_pushuinteger(L, fn((lua_UInteger)TOBIT(L, 1),                    \
-                          (unsigned)luaL_checknumber(L, 2)));            \
-    return 1;                                                           \
-  }  
-  
+
+// Added TH
+// TH:08.08.2017: The assignments to local vars in the
+// macro lead to better code with GCC when expanding brol and bror macros,
+// because the compiler cannot now if the function calls to Lua
+// have side effects and call them on every occurence
+#define BIT_SH(name, fn)                              \
+  static int bit_ ## name(lua_State *L) {             \
+    lua_UInteger b= (lua_UInteger)TOBIT(L, 1);        \
+    unsigned sh = (unsigned)luaL_checknumber(L, 2);   \
+    bit_pushuinteger(L, fn(b,sh));                    \
+    return 1;                                         \
+  }
+
 #define brol(b, n)  ((b << n) | (b >> (32-n)))
-#define bror(b, n)  ((b << (32-n)) | (b >> n))  
+#define bror(b, n)  ((b << (32-n)) | (b >> n))
 
 MONADIC(bnot,  ~)
 VARIADIC(band, &=)
@@ -117,7 +125,7 @@ static int bit_isset( lua_State* L )
 {
   lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned pos = ( unsigned )luaL_checkinteger( L, 2 );
-  
+
   lua_pushboolean( L, val & ( 1 << pos ) ? 1 : 0 );
   return 1;
 }
@@ -127,17 +135,17 @@ static int bit_isclear( lua_State* L )
 {
   lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned pos = ( unsigned )luaL_checkinteger( L, 2 );
-  
+
   lua_pushboolean( L, val & ( 1 << pos ) ? 0 : 1 );
   return 1;
 }
 
 // Lua: res = set( value, pos1, pos2, ... )
 static int bit_set( lua_State* L )
-{ 
+{
   lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned total = lua_gettop( L ), i;
-  
+
   for( i = 2; i <= total; i ++ )
     val |= 1 << ( unsigned )luaL_checkinteger( L, i );
   bit_pushuinteger( L, ( lua_UInteger )val );
@@ -149,11 +157,11 @@ static int bit_clear( lua_State* L )
 {
   lua_UInteger val = ( lua_UInteger )TOBIT( L, 1 );
   unsigned total = lua_gettop( L ), i;
-  
+
   for( i = 2; i <= total; i ++ )
     val &= ~( 1 << ( unsigned )luaL_checkinteger( L, i ) );
   bit_pushuinteger( L, ( lua_UInteger )val );
-  return 1; 
+  return 1;
 }
 
 //TH: "Borrowed" from luaBitop
@@ -186,9 +194,9 @@ const LUA_REG_TYPE bit_map[] = {
   { LSTRKEY( "clear" ),   LFUNCVAL( bit_clear ) },
   { LSTRKEY( "isset" ),   LFUNCVAL( bit_isset ) },
   { LSTRKEY( "isclear" ), LFUNCVAL( bit_isclear ) },
-  { LSTRKEY( "tohex" ), LFUNCVAL( bit_tohex ) }, // TH
-  { LSTRKEY("rol"),	LFUNCVAL(bit_rol) }, // TH
-  { LSTRKEY("ror"),	LFUNCVAL(bit_ror) }, // TH
+  { LSTRKEY( "tohex" ),   LFUNCVAL( bit_tohex ) }, // TH
+  { LSTRKEY("rol"),       LFUNCVAL( bit_rol ) }, // TH
+  { LSTRKEY("ror"),       LFUNCVAL( bit_ror ) }, // TH
   { LNILKEY, LNILVAL}
 };
 

--- a/src/modules/uart.c
+++ b/src/modules/uart.c
@@ -135,7 +135,10 @@ static int uart_read( lua_State* L )
   luaL_buffinit( L, &b );
   while( 1 )
   {
-    if( ( res = platform_uart_recv( id, timer_id, timeout ) ) == -1 )
+	// TH: First try without timeout to avoid recv FIFO overflows because of timer overhead
+	res=platform_uart_recv( id, timer_id, 0 );
+	if ( res== -1 && timeout>0 )  res = platform_uart_recv( id, timer_id, timeout ); // Now try with timeout if one was given
+    if( res  == -1 ) // still no char ...
       break; 
     cres = ( char )res;
     count ++;


### PR DESCRIPTION
These is a collection of all patches I made over the last months.

There are around three topics:
a) UART and XMODEM
When I implemented eLua on my FPGA platform I run into overrun problems when using the recv command with high data rates (500.000bit/s). I was successfully able to tune the coding a bit: I changed to code to only check timers when there is no char available (so always call platform_s_uart_recv with a timeout of 0 first).
In addition I added support for xmodem 1K. This is not so much relevant for eLua, where downloaded scripts are usually small, but it adds convenience. Maybe my default buffer setting of 4K  maybe to large for platform tight on memory. It would be better to make it configurable in the board definition file.

b) virtual timer
I found a few minor bugs in the virtual timer implementation. 

c)Bit library
The library didn't work with numbers >=0x80000000, at least when eLua is compiled with doubles as numbers. This reason is that the  C library helper function which converts a double to a signed 32 bit integer is setting the result to +MAXINT when the value of the double is larger then +MAXINT.
So 0x80000000 is converted to 0x7FFFFFFF. The statemment
`print(string.format("%x",bit.band(0x80000000,0x80000000))) `
resulted output "7fffffff" instead of 80000000.
As a first workaround I just changed the bit library to use unsigned ints. This looks more "natural" at a first glance, but as also drawbacks, e.g. that lua compiled with integers as numbers will behaves differently (although not incorrect).

I have also tried to use [http://bitop.luajit.org/](http://bitop.luajit.org/). It worked well, but it was not compatible with the cpu.r/w functions, because they expect unsigned numbers and failed when converting a negative  double number to an unsigned 32 Bit int , so I switched back to my first patch.

I checked the bit32 module in Lua 5.2. It works returns unsigned  numbers, but it accepts positive and negative numbers and also numbers larger then 2^32. It uses only the lower 32Bit of such numbers which basically, which is effectively treating applying a modulo 32 operation to every inbound numbers.
This is the most intuitive looking approach in my opinion, although it also lacks consistency between floating point and integer builds. 

At the end I'm not so happy with the current state of the bit library, because it doesn't deal with well with input values outside the range 0..2^32-1. What do you think?

 







