### PR TITLE
Add some support for out-of-tree builds

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -111,6 +111,11 @@ local default_platform_conf = {
   pre_generate_section = function() return true end,
 }
 
+-- Default table for extra configuration (same as above)s
+local default_extra_conf  = {
+  get_extra_modules = function() end,
+}
+
 -- Sanity code
 -- These are more checks added to the generated header file
 -- Some of these are the result of pure paranoia. Nevertheless, they seem to work.
@@ -224,6 +229,12 @@ function compile_board( fname, boardname )
     plconf = require( "src.platform." .. platform .. ".build_config" )
   end
 
+  -- Find and require the extra build configuration if specified
+  local extraconf = default_extra_conf
+  if utils.is_file( utils.concat_path{ comp.extras, 'build_config.lua' } ) then
+    extraconf = require( comp.extras .. ".build_config" )
+  end
+
   -- Read platform specific components/configs
   plconf.add_platform_components( components, boardname, desc.cpu )
   plconf.add_platform_configs( configs, boardname, desc.cpu )
@@ -275,6 +286,7 @@ function compile_board( fname, boardname )
   header = header .. sanity_code
 
   -- Generate module configuration
+  mgen.add_extra_modules( extraconf.get_extra_modules() )
   gen, err = mgen.gen_module_list( desc, plconf, platform, boardname )
   if not gen then return false, err end
   header = header .. gen

--- a/config/modules.lua
+++ b/config/modules.lua
@@ -47,6 +47,10 @@ local all_generic_modules = {}
 utils.concat_tables( all_generic_modules, lua_modules )
 utils.concat_tables( all_generic_modules, elua_generic_modules )
 
+function add_extra_modules( exmodules )
+  utils.concat_tables( all_generic_modules, exmodules )
+end
+
 -- Return the auxlib name of a given module
 local function get_auxlib( m, t )
   t = t or all_generic_modules


### PR DESCRIPTION
This commit allows the build system to be used with directories outside of the eLua tree,
using the new "conf" and "extraconf" arguments to the builder.

This commit contains code from both @jsnyder and @darren1713.