### PR TITLE
New feature: memory error callback

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -201,6 +201,8 @@ function compile_board( fname, boardname )
 #ifndef __GENERATED_%s_H__
 #define __GENERATED_%s_H__
 
+#include <stddef.h>
+
 ]], cboardname, cboardname )
   local desc, err = dofile( fname )
   if not desc then return false, err end

--- a/config/configurations.lua
+++ b/config/configurations.lua
@@ -97,6 +97,10 @@ local function ram_generator( desc, vals, generated )
   use_multiple_allocator = #startvals > 1
   local gstr = gen.simple_gen( "MEM_START_ADDRESS", vals, generated )
   gstr = gstr .. gen.simple_gen( "MEM_END_ADDRESS", vals, generated )
+  if vals.MEM_ERROR_CALLBACK then
+    gstr = gstr .. gen.simple_gen( "MEM_ERROR_CALLBACK", vals, generated )
+    gstr = gstr .. sf( "void %s( size_t );\n", vals.MEM_ERROR_CALLBACK.value )
+  end
   return gstr
 end
 
@@ -168,6 +172,7 @@ function init()
       internal_rams = at.int_attr( '_NUM_INTERNAL_RAMS', 0, nil, 1 ), 
       ext_start = at.array_of( at.combine_attr( 'MEM_START_ADDRESS', { at.int_attr( '' ), at.string_attr( '' ) } ) ),
       ext_size = at.array_of( at.combine_attr( 'MEM_END_ADDRESS', { at.int_attr( '', 1 ), at.string_attr( '' ) } ) ),
+      memory_error_callback = at.string_attr( 'MEM_ERROR_CALLBACK', 120, '' ),
     },
     required = { internal_rams = 1, ext_start = {}, ext_size = {} }
   }

--- a/inc/dlmalloc.h
+++ b/inc/dlmalloc.h
@@ -1,6 +1,8 @@
 #ifndef __MALLOC_H__
 #define __MALLOC_H__
 
+#include "platform_conf.h"
+
 // BogdanM: dlmalloc() tuning for eLua
 
 #include <unistd.h>
@@ -17,6 +19,11 @@ extern void* elua_sbrk( ptrdiff_t incr );
 #define DEFAULT_GRANULARITY       256 
 #define malloc_getpagesize        256
 #define REALLOC_ZERO_BYTES_FREES
+
+#ifdef MEM_ERROR_CALLBACK
+#define CORRUPTION_ERROR_ACTION(m) MEM_ERROR_CALLBACK(0)
+#define USAGE_ERROR_ACTION(m,p) MEM_ERROR_CALLBACK(0)
+#endif
 
 /*
   This is a version (aka dlmalloc) of malloc/free/realloc written by

--- a/inc/validate.h
+++ b/inc/validate.h
@@ -98,6 +98,12 @@
 #if defined( BUILD_ADVANCED_SHELL ) && !defined( BUILD_SHELL )
   #error "BUILD_ADVANCED_SHELL needs BUILD_SHELL"
 #endif
+
+// The memory error callback can only be enabled when using either the muliple allocator or the simple allocator
+// (but not the built-in allocator)
+#if defined( MEM_ERROR_CALLBACK ) && !defined( USE_MULTIPLE_ALLOCATOR ) && !defined( USE_SIMPLE_ALLOCATOR )
+  #error "A memory error callback can only be specified when using the multiple allocator or the simple allocator, but not the built-in allocator"
+#endif
   
 #endif // #ifndef __VALIDATE_H__
 

--- a/src/newlib/stubs.c
+++ b/src/newlib/stubs.c
@@ -493,12 +493,22 @@ struct mallinfo mallinfo( void )
 
 void* _malloc_r( struct _reent* r, size_t size )
 {
-  return CNAME( malloc )( size );
+  void *res = CNAME( malloc )( size );
+#ifdef MEM_ERROR_CALLBACK
+  if ( res == NULL )
+    MEM_ERROR_CALLBACK( size );
+#endif
+  return res;
 }
 
 void* _calloc_r( struct _reent* r, size_t nelem, size_t elem_size )
 {
-  return CNAME( calloc )( nelem, elem_size );
+  void *res = CNAME( calloc )( nelem, elem_size );
+#ifdef MEM_ERROR_CALLBACK
+  if ( res == NULL )
+    MEM_ERROR_CALLBACK( nelem * elem_size );
+#endif
+  return res;
 }
 
 void _free_r( struct _reent* r, void* ptr )
@@ -508,7 +518,12 @@ void _free_r( struct _reent* r, void* ptr )
 
 void* _realloc_r( struct _reent* r, void* ptr, size_t size )
 {
-  return CNAME( realloc )( ptr, size );
+  void *res = CNAME( realloc )( ptr, size );
+#ifdef MEM_ERROR_CALLBACK
+  if ( res == NULL && size > 0 )
+    MEM_ERROR_CALLBACK( size );
+#endif
+  return res;
 }
 
 #endif // #ifdef USE_MULTIPLE_ALLOCATOR


### PR DESCRIPTION
This PR adds the possibility of specifying a memory error callback in
the "ram" element of the "config" section. The new configuration
attribute is called "memory_error_callback" and its value is the name of
a function with the signature "void f(size_t)" that will be called
automatically in the following cases:

- when malloc, calloc, or realloc (with the 'size' argument greater than
  0) return NULL. The callback function will be called with the 'size'
  argument of the allocation function.
- when the allocator encounters an internal error (only when using the
  'multiple' allocator). The callback function will be called with the
  argument set to 0.

For now, this feature is only availabsle when using the multiple
allocator or the simple allocator, not the built-in libc allocator.

Usage example (in the board configuration file):

```
   config = {
     ram = { memory_error_callback = "memory_error" }
   }
```