### PR TITLE
stm32f4 exti fixes

### DIFF
--- a/src/platform/stm32f4/platform_int.c
+++ b/src/platform/stm32f4/platform_int.c
@@ -208,7 +208,7 @@ static int gpioh_set_int_status( elua_int_id id, elua_int_resnum resnum, int sta
   if( status == PLATFORM_CPU_ENABLE )
   {
     // Configure port for interrupt line
-    //GPIO_EXTILineConfig( PLATFORM_IO_GET_PORT( resnum ), PLATFORM_IO_GET_PIN( resnum ) );
+    SYSCFG_EXTILineConfig( PLATFORM_IO_GET_PORT( resnum ), PLATFORM_IO_GET_PIN( resnum ) );
 
     EXTI_StructInit(&exti_init_struct);
     exti_init_struct.EXTI_Line = exti_line[ exint_gpio_to_src( resnum ) ];

--- a/src/platform/stm32f4/platform_int.c
+++ b/src/platform/stm32f4/platform_int.c
@@ -74,17 +74,20 @@ static int exint_gpio_to_src( pio_type piodata )
 static void all_exti_irqhandler( int line )
 {
   u16 v, port, pin;
-  
-  v = exti_line_to_gpio( line );
-  port = PLATFORM_IO_GET_PORT( v );
-  pin = PLATFORM_IO_GET_PIN( v );
 
-  if( EXTI->RTSR & (1 << line ) && platform_pio_op( port, 1 << pin, PLATFORM_IO_PIN_GET ) )
-    cmn_int_handler( INT_GPIO_POSEDGE, v );
-  if( EXTI->FTSR & (1 << line ) && ( platform_pio_op( port, 1 << pin, PLATFORM_IO_PIN_GET ) == 0 ) )
-    cmn_int_handler( INT_GPIO_NEGEDGE, v );
+  if( EXTI_GetITStatus( exti_line[ line ] ) == SET )
+  {
+    v = exti_line_to_gpio( line );
+    port = PLATFORM_IO_GET_PORT( v );
+    pin = PLATFORM_IO_GET_PIN( v );
 
-  EXTI_ClearITPendingBit( exti_line[ line ] );
+    if( EXTI->RTSR & (1 << line ) && platform_pio_op( port, 1 << pin, PLATFORM_IO_PIN_GET ) )
+      cmn_int_handler( INT_GPIO_POSEDGE, v );
+    if( EXTI->FTSR & (1 << line ) && ( platform_pio_op( port, 1 << pin, PLATFORM_IO_PIN_GET ) == 0 ) )
+      cmn_int_handler( INT_GPIO_NEGEDGE, v );
+
+    EXTI_ClearITPendingBit( exti_line[ line ] );
+  }
 }
 
 void EXTI0_IRQHandler()


### PR DESCRIPTION
I wanted to use the external interrupts on an stm32f4 board and came across a couple of issues which this PR fixes:

1 - the code to select which port was connected to the external interrupt line was commented out and
used the wrong function name.

2 - once the interrupts were being generated, the irq handler appears to be called even when the irq pending register bit is not set and this was causing too many interrupts to be passed down to the lua code. Checking the state of the pending register by calling EXTI_GetITStatus() fixed the problem and I note that all examples I could find on the internet of using external interrupts do call that function so I guess that it must be used. I don't know why the irq handler is being invoked when the pending register bit is not set, but it is.
