### PR TITLE
Add CI support via Github actions

### DIFF
--- a/.github/workflows/build_elua.yml
+++ b/.github/workflows/build_elua.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+          sudo apt-get install lua5.1
+          sudo apt-get install luarocks
+          sudo apt-get install gcc-arm-none-eabi
+          sudo luarocks install luafilesystem
+          sudo luarocks install lpack
+          sudo luarocks install md5
+          
+
+    - name: Build elua
+      run: |
+        lua .circleci/ci_builder.lua


### PR DESCRIPTION
This adds support for CI via Github actions. I have adapted it from the .circleci/config.yml
I couldn't find a Debian-stretch image for the agent, so I chose an ubuntu-20.04 image as the closest match. 